### PR TITLE
Fix README link of remark-breaks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ attacks.
 *   [`remark-github`](https://github.com/remarkjs/remark-github)
     — link references to commits, issues, pull-requests, and users, like on
     GitHub
-*   [`remark-breaks`](https://github.com/remarkjs/remark-frontmatter)
+*   [`remark-breaks`](https://github.com/remarkjs/remark-breaks)
     — support hard breaks without needing spaces or escapes
 *   [`remark-frontmatter`](https://github.com/remarkjs/remark-frontmatter)
     — support frontmatter (YAML, TOML, and more)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Fixes a link on README. Pretty basic PR

<!--do not edit: pr-->
